### PR TITLE
[BUGFIX]: Backend Module is not working with TYPO3 v11

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -2,6 +2,12 @@
 
 defined('TYPO3_MODE') or die('Access denied!');
 
+$managementController = \B13\Proxycachemanager\Controller\ManagementController::class;
+if (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class)
+        ->getMajorVersion() < 10) {
+    $managementController = 'Management';
+}
+
 $proxyCacheManagerConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('proxycachemanager');
 if ($proxyCacheManagerConfiguration['showBackendModule'] ?? false) {
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
@@ -9,7 +15,7 @@ if ($proxyCacheManagerConfiguration['showBackendModule'] ?? false) {
         'site',
         'cdn_cache',
         'bottom',
-        ['Management' => 'index,clearTag,purgeUrl'],
+        [$managementController => 'index,clearTag,purgeUrl'],
         [
             'access' => 'user,group',
             'icon' => 'EXT:proxycachemanager/Resources/Public/Icons/CacheModule.png',


### PR DESCRIPTION
TYPO3 v11 requires the fully-qualified controller class name as array key for the allowed controller actions within the plugin configuration.