### PR TITLE
[BUGFIX] Fixes flushAllUrls for CloudflareProxyProvider

### DIFF
--- a/Classes/Provider/CloudflareProxyProvider.php
+++ b/Classes/Provider/CloudflareProxyProvider.php
@@ -92,22 +92,15 @@ class CloudflareProxyProvider implements ProxyProviderInterface, LoggerAwareInte
         if (!$this->isActive()) {
             return;
         }
-        if (empty($urls)) {
-            foreach ($this->getZones() as $domain => $zoneId) {
-                try {
-                    $this->getClient($zoneId)->post('purge_cache', ['json' => ['purge_everything' => true]]);
-                } catch (TransferException $e) {
-                    $this->logger->error('Could not flush URLs for {zone} via POST "purge_cache"', [
-                        'urls' => $urls,
-                        'zone' => $zoneId,
-                        'exception' => $e,
-                    ]);
-                }
-            }
-        } else {
-            $groupedUrls = $this->groupUrlsByAllowedZones($urls);
-            foreach ($groupedUrls as $zoneId => $urls) {
-                $this->purgeInChunks($zoneId, $urls);
+        foreach ($this->getZones() as $domain => $zoneId) {
+            try {
+                $this->getClient($zoneId)->post('purge_cache', ['json' => ['purge_everything' => true]]);
+            } catch (TransferException $e) {
+                $this->logger->error('Could not flush URLs for {zone} via POST "purge_cache"', [
+                    'urls' => $urls,
+                    'zone' => $zoneId,
+                    'exception' => $e,
+                ]);
             }
         }
     }


### PR DESCRIPTION
Drops the purge by chunks from the flushAllUrls of the CloudflareProxyProvider since it can result in hundreds of purge requests to the Cloudflare API depending on the size of the project