### PR TITLE
[BUGFIX] Use correct guzzle handler

### DIFF
--- a/Classes/Provider/CloudflareProxyProvider.php
+++ b/Classes/Provider/CloudflareProxyProvider.php
@@ -17,6 +17,7 @@ namespace B13\Proxycachemanager\Provider;
  */
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Exception\TransferException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -178,9 +179,17 @@ class CloudflareProxyProvider implements ProxyProviderInterface, LoggerAwareInte
     protected function initializeClient(string $zoneId, string $apiToken)
     {
         $httpOptions = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
-        if (isset($httpOptions['handler']) && empty($httpOptions['handler'])) {
-            // let guzzle choose hander
-            unset($httpOptions['handler']);
+        if (isset($httpOptions['handler'])) {
+            if (is_array($httpOptions['handler'] && !empty($httpOptions['handler']))) {
+                $stack = HandlerStack::create();
+                foreach ($httpOptions['handler'] as $handler) {
+                    $stack->push($handler);
+                }
+                $httpOptions['handler'] = $stack;
+            }
+            else {
+                unset($httpOptions['handler']);
+            }
         }
         $httpOptions['base_uri'] = str_replace('{zoneId}', $zoneId, $this->baseUrl);
         $httpOptions['headers']['Content-Type'] = 'application/json';

--- a/Classes/Provider/FastlyProxyProvider.php
+++ b/Classes/Provider/FastlyProxyProvider.php
@@ -17,6 +17,7 @@ namespace B13\Proxycachemanager\Provider;
  */
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 
 class FastlyProxyProvider implements ProxyProviderInterface
 {
@@ -92,6 +93,18 @@ class FastlyProxyProvider implements ProxyProviderInterface
     protected function initializeClient($serviceId, $apiToken)
     {
         $httpOptions = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
+        if (isset($httpOptions['handler'])) {
+            if (is_array($httpOptions['handler'] && !empty($httpOptions['handler']))) {
+                $stack = HandlerStack::create();
+                foreach ($httpOptions['handler'] as $handler) {
+                    $stack->push($handler);
+                }
+                $httpOptions['handler'] = $stack;
+            }
+            else {
+                unset($httpOptions['handler']);
+            }
+        }
         $httpOptions['verify'] = filter_var($httpOptions['verify'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $httpOptions['verify'];
         $httpOptions['base_uri'] = str_replace('{serviceId}', $serviceId, $this->baseUrl);
         $httpOptions['headers']['Fastly-Key'] = $apiToken;


### PR DESCRIPTION
Fixes #23 , the check is the same for both providers, so it could be refactored into a common getHandler function or something. Also not sure if you would actually want to apply same handlers as the ones configured for Typo3, in case of negative, then it should be as simple as always unsetting the ['handler'] key.
 