### PR TITLE
[BUGFIX] Remove vendor name from backend module registration

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -2,20 +2,14 @@
 
 defined('TYPO3_MODE') or die('Access denied!');
 
-$managementController = \B13\Proxycachemanager\Controller\ManagementController::class;
-if (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class)
-        ->getMajorVersion() < 10) {
-    $managementController = 'Management';
-}
-
 $proxyCacheManagerConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('proxycachemanager');
 if ($proxyCacheManagerConfiguration['showBackendModule'] ?? false) {
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'B13.proxycachemanager',
+        'proxycachemanager',
         'site',
         'cdn_cache',
         'bottom',
-        [$managementController => 'index,clearTag,purgeUrl'],
+        [\B13\Proxycachemanager\Controller\ManagementController::class => 'index,clearTag,purgeUrl'],
         [
             'access' => 'user,group',
             'icon' => 'EXT:proxycachemanager/Resources/Public/Icons/CacheModule.png',


### PR DESCRIPTION
Also remove short Controller name for
older TYPO3 versions.