### PR TITLE
[BUGFIX] Fix flushing of all cache entries

### DIFF
--- a/Classes/Cache/Backend/ReverseProxyCacheBackend.php
+++ b/Classes/Cache/Backend/ReverseProxyCacheBackend.php
@@ -62,13 +62,12 @@ class ReverseProxyCacheBackend extends Typo3DatabaseBackend implements Transient
      */
     public function flush()
     {
-        parent::flush();
-
         // make the HTTP Purge call
         if ($this->reverseProxyProvider->isActive()) {
             $urls = $this->getAllCachedUrls();
             $this->reverseProxyProvider->flushAllUrls($urls);
         }
+        parent::flush();
     }
 
     /**


### PR DESCRIPTION
Adapts the processing in ReverseProxyCacheBackend->flush to ensure the cached urls are processed before the cache table is truncated.

Resolves: #38